### PR TITLE
fix: pin tRPC version to 9.27.* to correspond with trpc-sveltekit

### DIFF
--- a/templates/+prisma_trpc/package.txt
+++ b/templates/+prisma_trpc/package.txt
@@ -1,1 +1,1 @@
-npm install --save --package-lock-only --no-package-lock @trpc/client @trpc/server trpc-sveltekit trpc-transformer zod && npm install --save -D --package-lock-only --no-package-lock @prisma/client prisma
+npm install --save --package-lock-only --no-package-lock @trpc/client@"^9.27.2" @trpc/server@"^9.27.2" trpc-sveltekit trpc-transformer zod && npm install --save -D --package-lock-only --no-package-lock @prisma/client prisma

--- a/templates/+trpc/package.txt
+++ b/templates/+trpc/package.txt
@@ -1,1 +1,1 @@
-npm install --save --package-lock-only --no-package-lock @trpc/client @trpc/server trpc-sveltekit trpc-transformer zod
+npm install --save --package-lock-only --no-package-lock @trpc/client@"^9.27.2" @trpc/server@"^9.27.2" trpc-sveltekit trpc-transformer zod


### PR DESCRIPTION
Pertains to #23. Currently, the RPC client and server in `templates/trpc/package.json` and `templates/prisma_trpc/package.json` have no specified versions, causing initial `package.json` creation to fail when installed in conjuction with `trpc-sveltekit`. This PR simply pins the versions to `^9.27.2` in both these files.

There is currently a [PR](https://github.com/icflorescu/trpc-sveltekit/pull/29) open in `trpc-sveltekit` to update it to be compatible with tRPC 10, but this fixes this issue for now.