### PR TITLE
Updated Vite version in templates

### DIFF
--- a/templates/base_javascript/package.json
+++ b/templates/base_javascript/package.json
@@ -18,7 +18,7 @@
 		"svelte-check": "^2.7.1",
 		"svelte-preprocess": "^4.10.7",
 		"typescript": "^4.7.4",
-		"vite": "^3.1.0"
+		"vite": "^4.0.0"
 	},
 	"type": "module",
 	"dependencies": {

--- a/templates/base_typescript/package.json
+++ b/templates/base_typescript/package.json
@@ -19,7 +19,7 @@
 		"svelte-preprocess": "^4.10.7",
 		"tslib": "^2.3.1",
 		"typescript": "^4.7.4",
-		"vite": "^3.1.0"
+		"vite": "^4.0.0"
 	},
 	"type": "module",
 	"dependencies": {

--- a/templates/standard/package.json
+++ b/templates/standard/package.json
@@ -31,7 +31,7 @@
 		"tailwindcss": "^3.1.8",
 		"tslib": "^2.3.1",
 		"typescript": "^4.7.4",
-		"vite": "^3.1.0",
+		"vite": "^4.0.0",
 		"@tailwindcss/forms": "^0.5.3",
 		"@rgossiaux/svelte-headlessui": "^1.0.2"
 	},


### PR DESCRIPTION
When running `npx create-t3svelte-app` I got an error while installing dependencies. I bumped Vite's version to `^4.0.0` and seems like that fixed the issue.