### PR TITLE
Adding SvelteKit Auth/Auth.js to the main stack

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -47,6 +47,7 @@ async function promptForMissingOptions(options) {
 			{ name: 'tRPC', checked: true },
 			{ name: 'Prisma ORM', checked: true },
 			{ name: 'Tailwind CSS', checked: true },
+      { name: 'SvelteKit Auth', checked: true }
 		],
 	})
 
@@ -59,6 +60,7 @@ async function promptForMissingOptions(options) {
 		choices: [
 			{ name: 'Prisma ORM', checked: true },
 			{ name: 'Tailwind CSS', checked: true },
+      { name: 'SvelteKit Auth', checked: true }
 		],
 	})
 
@@ -205,6 +207,7 @@ async function promptForMissingOptions(options) {
 	const prisma = techOptions.includes('Prisma ORM')
 	const scriptLang = techOptions.includes('TypeScript') ? 'TypeScript' : 'JavaScript'
 	const tailwind = techOptions.includes('Tailwind CSS')
+  const svelteKitAuth = techOptions.includes('SvelteKit Auth')
 
 	//Tooling
 	const eslint = toolOptions.includes('ESLint')
@@ -228,6 +231,7 @@ async function promptForMissingOptions(options) {
 			trpc: trpc,
 			prisma: prisma,
 			tailwind: tailwind,
+      svelteKitAuth: svelteKitAuth,
 
 			//Tooling
 			eslint: eslint,

--- a/src/main.js
+++ b/src/main.js
@@ -57,6 +57,7 @@ async function copyOptionalFiles(options, templateBaseDir) {
     dirArray.push(templateBaseDir + '+prisma_trpc')
   else if (selectedOptionals.includes('trpc')) dirArray.push(templateBaseDir + '+trpc')
   else if (selectedOptionals.includes('prisma')) dirArray.push(templateBaseDir + '+prisma')
+  else if (selectedOptionals.includes('svelteKitAuth')) dirArray.push(templateBaseDir + '+sveltekitauth')
 
   if (selectedOptionals.includes('tailwind')) dirArray.push(templateBaseDir + '+tailwind')
 

--- a/templates/+sveltekitauth/package.txt
+++ b/templates/+sveltekitauth/package.txt
@@ -1,0 +1,1 @@
+npm install --save -D --package-lock-only --no-package-lock @auth/sveltekit @auth/core

--- a/templates/+sveltekitauth/src/hooks.server.ts
+++ b/templates/+sveltekitauth/src/hooks.server.ts
@@ -1,0 +1,10 @@
+import SvelteKitAuth from '@auth/sveltekit'
+import Discord from '@auth/core/providers/discord'
+// Run `npm run check` to generate types after setting the environment variables
+import { DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET } from '$env/static/private'
+
+export const handle = SvelteKitAuth({
+  providers: [
+    Discord({ clientId: DISCORD_CLIENT_ID, clientSecret: DISCORD_CLIENT_SECRET }),
+  ]
+});

--- a/templates/+sveltekitauth/src/routes/+layout.server.ts
+++ b/templates/+sveltekitauth/src/routes/+layout.server.ts
@@ -1,0 +1,8 @@
+// Example of getting the current user's session
+import type { LayoutServerLoad } from "./$types"
+
+export const load: LayoutServerLoad = async (event) => {
+  return {
+    session: await event.locals.getSession(),
+  }
+}


### PR DESCRIPTION
Implementing Vercel's official auth solution for SvelteKit.

## Checklist

- [x] Auth.js (as a standalone package)
- [] Auth.js + Prisma
- [] Auth.js + Prisma + tRPC
- [] Update README with information about this package